### PR TITLE
use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "osc_sdk_python/osc-api"]
 	path = osc_sdk_python/osc-api
-	url = git@github.com:outscale/osc-api.git
+	url = https://github.com/outscale/osc-api.git


### PR DESCRIPTION
in order to use ssh link you need Github to know your rsa key, so be part of Outscale.
As this repo is open source, it doesn't made a lot of sense to use that over https link