### PR TITLE
Better error information if plateform does not work

### DIFF
--- a/osc_sdk_python/requester.py
+++ b/osc_sdk_python/requester.py
@@ -12,8 +12,10 @@ class Requester:
         self.endpoint = endpoint
 
     def send(self, uri, payload):
-        r = requests.post(self.endpoint, data=payload,
+        response = requests.post(self.endpoint, data=payload,
                           headers=self.auth.forge_headers_signed(uri, payload),
                           verify=False)
-        return r.json()
+        if response.status_code != 200:
+             raise requests.HTTPError('url:{}. {}: {}'.format(response.url, response.status_code, response.text))
+        return response.json()
 


### PR DESCRIPTION
When something went wrong on target plateforme (api endpoint) error was unclear. Now error is more verbose and related to the http problem itself, not json parsing error. 