### PR TITLE
update runamel and user-agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,8 @@ We’ll do our best to review your pull request (or “PR” for short) quickly.
 Each PR should, as much as possible, address just one issue and be self-contained. 
 Smaller the set of changes in the pull request is, the quicker it can be reviewed and 
 merged - if you have ten small, unrelated changes, then go ahead and submit ten PRs.
+
+## RELEASE TODO
+- update VERSION in authentication.py
+- Push a tag and a branch of current release
+- update number in version in setup.py

--- a/osc_sdk_python/authentication.py
+++ b/osc_sdk_python/authentication.py
@@ -2,13 +2,16 @@ import datetime
 import hashlib
 import hmac
 
+VERSION = "0.9.16-git"
+DEFAULT_USER_AGENT = "osc-sdk-python/" + VERSION
 
 class Authentication:
     def __init__(self, credentials, host,
                  method='POST', service='api',
                  content_type='application/json; charset=utf-8',
                  algorithm='OSC4-HMAC-SHA256',
-                 signed_headers = 'content-type;host;x-osc-date'):
+                 signed_headers = 'content-type;host;x-osc-date',
+                 user_agent = DEFAULT_USER_AGENT):
         self.access_key = credentials.get_ak()
         self.secret_key = credentials.get_sk()
         self.host = host
@@ -18,6 +21,7 @@ class Authentication:
         self.service = service
         self.algorithm = algorithm
         self.signed_headers = signed_headers
+        self.user_agent = user_agent
 
     def forge_headers_signed(self, uri, request_data):
         date_iso, date = self.build_dates()
@@ -32,7 +36,7 @@ class Authentication:
             'Content-Type': self.content_type,
             'X-Osc-Date': date_iso,
             'Authorization': authorisation,
-            'User-Agent': 'oAPI CLI v0.1 - 2018-09-28',
+            'User-Agent': self.user_agent,
         }
 
     def build_dates(self):

--- a/osc_sdk_python/call.py
+++ b/osc_sdk_python/call.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .authentication import Authentication
+from .authentication import DEFAULT_USER_AGENT
 from .credentials import Credentials
 from .requester import Requester
 import json
@@ -14,6 +15,7 @@ class Call(object):
         self.version = kwargs.pop('version', 'latest')
         self.host = kwargs.pop('host', None)
         self.ssl = kwargs.pop('_ssl', True)
+        self.user_agent = kwargs.pop("user_agent", DEFAULT_USER_AGENT)
 
     def api(self, action, **data):
         try:
@@ -24,7 +26,7 @@ class Call(object):
             protocol = 'https' if self.ssl else 'http'
             endpoint = '{protocol}://{host}{uri}'.format(**locals())
 
-            requester = Requester(Authentication(credentials, host), endpoint)
+            requester = Requester(Authentication(credentials, host, user_agent=self.user_agent), endpoint)
             return requester.send(uri, json.dumps(data))
         except Exception as err:
             raise err

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.20.0
-ruamel.yaml==0.15.100
+ruamel.yaml==0.16.5

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name='osc_sdk_python',
     version='0.9.16-git',
-    author="Selim Kac",
-    author_email="selim.kacer@outscale.com",
+    author="Outscal SAS",
+    author_email="opensource@outscale.com",
     description="Outscale Gateway python SDK",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setuptools.setup(
     ],
     install_requires=[
         'requests>=2.20.0',
-        'ruamel.yaml==0.15.94'
+        'ruamel.yaml==0.16.5'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='osc_sdk_python',
-    version='0.9.15',
+    version='0.9.16-git',
     author="Selim Kac",
     author_email="selim.kacer@outscale.com",
     description="Outscale Gateway python SDK",


### PR DESCRIPTION
It seems python 3.9 can't build runeamel any more, so we need to update it.

Note that I didn't try to build this version of an old python version.

also update user agent so it's more explicit than the current one.