### PR TITLE
Enable to use same file for credentials than osc-cli

### DIFF
--- a/osc_sdk_python/call.py
+++ b/osc_sdk_python/call.py
@@ -10,7 +10,8 @@ class Call(object):
         self.credentials = {'access_key': kwargs.pop('access_key', None),
                             'secret_key': kwargs.pop('secret_key', None),
                             'region': kwargs.pop('region', None),
-                            'profile': kwargs.pop('profile', 'default')}
+                            'profile': kwargs.pop('profile', 'default'),
+                            'osc_cli_profile': kwargs.pop('osc_cli_profile', None)}
         self.version = kwargs.pop('version', 'latest')
         self.host = kwargs.pop('host', None)
         self.ssl = kwargs.pop('_ssl', True)

--- a/osc_sdk_python/credentials.py
+++ b/osc_sdk_python/credentials.py
@@ -3,14 +3,16 @@ import os
 
 
 class Credentials:
-    def __init__(self, profile=None, access_key=None, secret_key=None, region=None):
+    def __init__(self, profile=None, access_key=None, secret_key=None, region=None, osc_cli_profile=None):
         if not self.load_credentials_from_env():
             if access_key is not None and secret_key is not None and region is not None:
                 self.access_key = access_key
                 self.secret_key = secret_key
                 self.region = region
+            elif osc_cli_profile is not None:
+                self.load_credentials_from_file(profile, True)
             elif profile is not None:
-                self.load_credentials_from_file(profile)
+                self.load_credentials_from_file(profile, False)
 
     def load_credentials_from_env(self):
         self.access_key = os.environ.get('OSC_ACCESS_KEY')
@@ -18,9 +20,11 @@ class Credentials:
         self.region = os.getenv('OSC_REGION', 'us-west-1')
         return self.access_key and self.secret_key
 
-    def load_credentials_from_file(self, profile):
+    def load_credentials_from_file(self, profile, is_osc_cli_profile):
+        path = '.osc_sdk/config.json' if is_osc_cli_profile else '.oapi_credentials'
+        region_field = 'region_name' if is_osc_cli_profile else 'region'
         try:
-            with open(os.path.join(os.path.expanduser('~'),'.oapi_credentials')) as f:
+            with open(os.path.join(os.path.expanduser('~'), path)) as f:
                 try:
                     credentials = json.load(f)
                     if not profile in credentials:
@@ -30,15 +34,15 @@ class Credentials:
                     else:
                         self.access_key = credentials.get(profile).get('access_key', '')
                         self.secret_key = credentials.get(profile).get('secret_key', '')
-                        self.region = credentials.get(profile).get('region', 'us-west-1')
+                        self.region = credentials.get(profile).get(region_field, 'us-west-1')
                 except ValueError:
-                    print ('Decoding json of "~/.oapi_credentials" has failed.')
+                    print ('Decoding json of "', path, '" has failed.')
                     raise
                 except AttributeError as e:
                     print ('{}'.format(e))
                     raise
         except IOError:
-            print ('"~/.oapi_credentials" not found.')
+            print ('"', path, '" not found.')
             raise
 
     def get_region(self):


### PR DESCRIPTION
This PR rework #21 so we could use osc_cli credential file
but still use `oapi_credentials` as default profile file.

If we want to use osc_cli file, we need to use osc_cli_profile instead of profile in Gateway creation.

close #21 