### PR TITLE
Fix credential parsing and ordering

### DIFF
--- a/osc_sdk_python/call.py
+++ b/osc_sdk_python/call.py
@@ -5,13 +5,12 @@ from .credentials import Credentials
 from .requester import Requester
 import json
 
-
 class Call(object):
     def __init__(self, **kwargs):
         self.credentials = {'access_key': kwargs.pop('access_key', None),
                             'secret_key': kwargs.pop('secret_key', None),
                             'region': kwargs.pop('region', None),
-                            'profile': kwargs.pop('profile', 'default')}
+                            'profile': kwargs.pop('profile', None)}
         self.version = kwargs.pop('version', 'latest')
         self.host = kwargs.pop('host', None)
         self.ssl = kwargs.pop('_ssl', True)

--- a/osc_sdk_python/credentials.py
+++ b/osc_sdk_python/credentials.py
@@ -4,59 +4,72 @@ import os
 ORIGINAL_PATH = os.path.join(os.path.expanduser('~'),'.oapi_credentials')
 STD_PATH = os.path.join(os.path.expanduser('~'),'.osc/config.json')
 DEFAULT_REGION="eu-west-2"
+DEFAULT_PROFILE="default"
 
 class Credentials:
-    def __init__(self, profile=None, access_key=None, secret_key=None, region=None):
-        if not self.load_credentials_from_env():
-            if access_key is not None and secret_key is not None and region is not None:
-                self.access_key = access_key
-                self.secret_key = secret_key
-                self.region = region
-            elif profile is not None:
-                self.load_credentials_from_file(profile)
+    def __init__(self, region, profile, access_key, secret_key):
+        if region == None:
+            region = DEFAULT_REGION
+        if profile == None:
+            profile = DEFAULT_PROFILE
+        # Set defaults
+        self.region = region
+        self.profile = profile
+        self.access_key = access_key
+        self.secret_key = secret_key
+        # Overide with old configuration if available
+        self.load_credentials_from_file(profile, ORIGINAL_PATH)
+        # Overide with standard configuration if available
+        self.load_credentials_from_file(profile, STD_PATH)
+        # Overide with environmental configuration if available
+        self.load_credentials_from_env()
+        # Overide with app parameters if provided
+        if access_key != None:
+            self.access_key = access_key
+        if secret_key != None:
+            self.secret_key = secret_key
+        if region != None:
+            self.region = DEFAULT_REGION
+
         self.check_options()
 
-    def check_options(self):
-        if self.access_key is None or len(self.access_key) == 0:
-            raise Exception("Invalid Outscale access key")
-        if self.secret_key is None or len(self.secret_key) == 0:
-            raise Exception("Invalid Outscale secret key")
+    def load_credentials_from_file(self, profile, file_path):
+        try:
+            with open(file_path) as f:
+                config = json.load(f)
+                profile = config.get(profile)
+                if profile == None:
+                    return
+                ak = profile.get("access_key")
+                if ak != None:
+                    self.access_key = ak
+                sk = profile.get("secret_key")
+                if sk != None:
+                    self.secret_key = sk
+                region = profile.get("region")
+                if region != None:
+                    self.region = region
+        except IOError:
+            pass
 
     def load_credentials_from_env(self):
-        self.access_key = os.environ.get('OSC_ACCESS_KEY')
-        self.secret_key = os.environ.get('OSC_SECRET_KEY')
-        self.region = os.getenv('OSC_REGION', DEFAULT_REGION)
-        return self.access_key and self.secret_key
+        ak = os.environ.get('OSC_ACCESS_KEY')
+        if ak != None:
+            self.access_key = ak
+        sk = os.environ.get('OSC_SECRET_KEY')
+        if sk != None:
+            self.secret_key = sk
+        region = os.environ.get('OSC_REGION')
+        if region != None:
+            self.region = region
 
-    def load_credentials_from_file_(self, profile, f):
-        try:
-            credentials = json.load(f)
-            if not profile in credentials:
-                self.access_key = ''
-                self.secret_key = ''
-                self.region = DEFAULT_REGION
-            else:
-                self.access_key = credentials.get(profile).get('access_key', '')
-                self.secret_key = credentials.get(profile).get('secret_key', '')
-                self.region = credentials.get(profile).get('region', DEFAULT_REGION)
-        except ValueError:
-            print ('Decoding json of "{}" has failed.'.format(f))
-            raise
-        except AttributeError as e:
-            print ('{}'.format(e))
-            raise
-
-    def load_credentials_from_file(self, profile):
-        try:
-            with open(STD_PATH) as f:
-                self.load_credentials_from_file_(profile, f)
-        except IOError:
-            try:
-                with open(ORIGINAL_PATH) as f:
-                    self.load_credentials_from_file_(profile, f)
-            except IOError:
-                print ('nor "', STD_PATH, '" nor "' ,ORIGINAL_PATH,'" found.')
-                raise
+    def check_options(self):
+        if self.access_key == None or len(self.access_key) == 0:
+            raise Exception("Invalid Outscale access key")
+        if self.secret_key == None or len(self.secret_key) == 0:
+            raise Exception("Invalid Outscale secret key")
+        if self.region == None or len(self.region) == 0:
+            raise Exception("Invalid Outscale region")
 
     def get_region(self):
         return self.region
@@ -66,6 +79,9 @@ class Credentials:
 
     def get_sk(self):
         return self.secret_key
+
+    def get_profile(self):
+        return self.profile
 
     def get_url_extension(self):
         return 'hk' if 'cn' in self.region else 'com'


### PR DESCRIPTION
Parameter filling should be priotized in this order (most prefered first):
- parameters directly passed to the tool
- environement variables
- configuration file
- legacy / old configuration file
- default file

Signed-off-by: Jérôme Jutteau <jerome.jutteau@outscale.com>