### PR TITLE
authentication: readd VERSION as a global variable

### DIFF
--- a/osc_sdk_python/authentication.py
+++ b/osc_sdk_python/authentication.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 
 from osc_sdk_python import __version__
+VERSION = __version__
 DEFAULT_USER_AGENT = "osc-sdk-python/" + __version__
 
 class Authentication:


### PR DESCRIPTION
It use to be the only way to get the version in python, and is used in osc-tui,
so changing that variable name would beak osc-tui.
Also as we have `DEFAULT_USER_AGENT`, keeping another global `VERSION` isn't that much a big deal.