### PR TITLE
credentials: profil have higer now priority to env

### DIFF
--- a/osc_sdk_python/credentials.py
+++ b/osc_sdk_python/credentials.py
@@ -10,19 +10,24 @@ class Credentials:
     def __init__(self, region, profile, access_key, secret_key):
         if region == None:
             region = DEFAULT_REGION
-        if profile == None:
+        if profile == None: # Env have higher priority if not specify
             profile = DEFAULT_PROFILE
+            # Overide with old configuration if available
+            self.load_credentials_from_file(profile, ORIGINAL_PATH)
+            # Overide with standard configuration if available
+            self.load_credentials_from_file(profile, STD_PATH)
+            # Overide with environmental configuration if available
+            self.load_credentials_from_env()
+        else:
+            # Overide with environmental configuration if available
+            self.load_credentials_from_env()
+            # Overide with old configuration if available
+            self.load_credentials_from_file(profile, ORIGINAL_PATH)
+            # Overide with standard configuration if available
+            self.load_credentials_from_file(profile, STD_PATH)
         # Set defaults
         self.region = region
         self.profile = profile
-        self.access_key = access_key
-        self.secret_key = secret_key
-        # Overide with old configuration if available
-        self.load_credentials_from_file(profile, ORIGINAL_PATH)
-        # Overide with standard configuration if available
-        self.load_credentials_from_file(profile, STD_PATH)
-        # Overide with environmental configuration if available
-        self.load_credentials_from_env()
         # Overide with app parameters if provided
         if access_key != None:
             self.access_key = access_key


### PR DESCRIPTION
Until now the AK/SK in env always had priority to the one in profil.
It was sometime confusing as it would ignore profil in oparameter if
env was set.

now:
if no profil are enter, env still have an higher priority to default profil.
otherwise profil have higher priority to env.
It is still posible to use partially complet profil, and complet
the profils informations with env
(examples have the region in config.json and AK/SK in env)

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>