### PR TITLE
add gateway.api_version

### DIFF
--- a/osc_sdk_python/outscale_gateway.py
+++ b/osc_sdk_python/outscale_gateway.py
@@ -80,6 +80,7 @@ class OutscaleGateway:
                 content = yaml.load(fi.read())
         except Exception as err:
             print('Problem reading {}:{}'.format(input_file, str(err)))
+        self.api_version = content['info']['version']
         for action, params in content['components']['schemas'].items():
             if action.endswith('Request'):
                 action_name = action.split('Request')[0]


### PR DESCRIPTION
Close #64

Note that I've use `api_version` instead of `gateway_version`

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>