### PR TITLE
add Gateway.update_credentials

### DIFF
--- a/osc_sdk_python/call.py
+++ b/osc_sdk_python/call.py
@@ -7,17 +7,28 @@ import json
 
 class Call(object):
     def __init__(self, logger=None, **kwargs):
-        self.credentials = {'access_key': kwargs.pop('access_key', None),
-                            'secret_key': kwargs.pop('secret_key', None),
-                            'region': kwargs.pop('region', None),
-                            'profile': kwargs.pop('profile', None),
-                            'email': kwargs.pop('email', None),
-                            'password': kwargs.pop('password', None)}
         self.version = kwargs.pop('version', 'latest')
         self.host = kwargs.pop('host', None)
         self.ssl = kwargs.pop('_ssl', True)
         self.user_agent = kwargs.pop("user_agent", DEFAULT_USER_AGENT)
         self.logger = logger
+        self.update_credentials(access_key=kwargs.pop('access_key', None),
+                                secret_key=kwargs.pop('secret_key', None),
+                                region=kwargs.pop('region', None),
+                                profile=kwargs.pop('profile', None),
+                                email=kwargs.pop('email', None),
+                                password=kwargs.pop('password', None))
+
+    def update_credentials(self, region=None, profile=None, access_key=None,
+                           secret_key=None, email=None, password=None):
+        self.credentials = {
+            'access_key': access_key,
+            'secret_key': secret_key,
+            'region': region,
+            'profile': profile,
+            'email': email,
+            'password': password
+        }
 
     def api(self, action, **data):
         try:

--- a/osc_sdk_python/outscale_gateway.py
+++ b/osc_sdk_python/outscale_gateway.py
@@ -72,6 +72,11 @@ class OutscaleGateway:
         else:
             self.retry = 1
 
+    def update_credentials(self, region=None, profile=None, access_key=None,
+                           secret_key=None, email=None, password=None):
+        self.call.update_credentials(region=region, profile=profile, access_key=access_key,
+                                     secret_key=secret_key, email=email, password=password)
+
     def _convert(self, input_file):
         structure = {}
         try:

--- a/osc_sdk_python/outscale_gateway.py
+++ b/osc_sdk_python/outscale_gateway.py
@@ -74,6 +74,12 @@ class OutscaleGateway:
 
     def update_credentials(self, region=None, profile=None, access_key=None,
                            secret_key=None, email=None, password=None):
+        """
+        destroy and create a new credential map use for each call.
+        so you can change your ak/sk, region without having to recreate the whole Gateway
+        as the object is recreate, you can't expect to keep parameter from the old configuration
+        example: just updating the password, without renter the login will fail
+        """
         self.call.update_credentials(region=region, profile=profile, access_key=access_key,
                                      secret_key=secret_key, email=email, password=password)
 


### PR DESCRIPTION
add Gateway.update_credentials, so we can use the same Gateway object for multiple accounts.

Usage

```python
from osc_sdk_python import Gateway
gw = Gateway(profile="default")
gw.ReadVms()['Vms'][1]['Tags']
gw.update_credentials(profile="my")
gw.ReadVms()['Vms'][1]['Tags']
```

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>