### PR TITLE
Remove custom retry mechanim + make gw calls threadsafe

### DIFF
--- a/osc_sdk_python/call.py
+++ b/osc_sdk_python/call.py
@@ -10,7 +10,8 @@ class Call(object):
         self.version = kwargs.pop('version', 'latest')
         self.host = kwargs.pop('host', None)
         self.ssl = kwargs.pop('_ssl', True)
-        self.user_agent = kwargs.pop("user_agent", DEFAULT_USER_AGENT)
+        self.user_agent = kwargs.pop('user_agent', DEFAULT_USER_AGENT)
+        self.max_retries = kwargs.pop('max_retries', 0)
         self.logger = logger
         self.update_credentials(access_key=kwargs.pop('access_key', None),
                                 secret_key=kwargs.pop('secret_key', None),
@@ -39,7 +40,7 @@ class Call(object):
             protocol = 'https' if self.ssl else 'http'
             endpoint = '{}://{}{}'.format(protocol, host, uri)
 
-            requester = Requester(Authentication(credentials, host, user_agent=self.user_agent), endpoint)
+            requester = Requester(Authentication(credentials, host, user_agent=self.user_agent), endpoint, self.max_retries)
             if self.logger != None:
                 self.logger.do_log("uri: " + uri + "\npayload:\n" + json.dumps(data, indent=2))
             return requester.send(uri, json.dumps(data))

--- a/osc_sdk_python/requester.py
+++ b/osc_sdk_python/requester.py
@@ -1,9 +1,16 @@
-import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 class Requester:
-    def __init__(self, auth, endpoint):
+    def __init__(self, auth, endpoint, max_retries=0, backoff_factor=0.5, status_forcelist=[400, 500]):
         self.auth = auth
         self.endpoint = endpoint
+        if max_retries > 0:
+            retry = Retry(total=max_retries, backoff_factor=backoff_factor, status_forcelist=status_forcelist)
+            self.adapter = HTTPAdapter(max_retries=retry)
+        else:
+            self.adapter = HTTPAdapter()
 
     def send(self, uri, payload):
         headers = None
@@ -12,6 +19,9 @@ class Requester:
         else:
             headers = self.auth.forge_headers_signed(uri, payload)
 
-        response = requests.post(self.endpoint, data=payload, headers=headers, verify=True)
-        response.raise_for_status()
-        return response.json()
+        with Session() as session:
+            session.mount("https://", self.adapter)
+            session.mount("http://", self.adapter)
+            response = session.post(self.endpoint, data=payload, headers=headers, verify=True,)
+            response.raise_for_status()
+            return response.json()


### PR DESCRIPTION
Hi,

this PR try to fix multiple things :

* usage of a gateway object is not threadsafe. Property  [action_name](https://github.com/outscale/osc-sdk-python/blob/master/osc_sdk_python/outscale_gateway.py#L179) can be overwrite by every thread of a threadpool, generating inconsistent api calls. A workaround is to use raw() method but it has no checks.
* retry mechanism don't works when technicals errors are raise (timeouts, internal server error, ...). To me it's better to use Retry class provided by urllib3 to manage retries, it works with more use cases.
* I don't know when this [line](https://github.com/outscale/osc-sdk-python/blob/master/osc_sdk_python/outscale_gateway.py#L171) can be executed because [requests](https://github.com/outscale/osc-sdk-python/blob/master/osc_sdk_python/requester.py#L16) raise automatically an HTTPError when an error code is returned. So I remove the block an let Retry make another call if necessary.