### PR TITLE
🐛 fix: read api version from spec

### DIFF
--- a/osc_sdk_python/outscale_gateway.py
+++ b/osc_sdk_python/outscale_gateway.py
@@ -69,7 +69,7 @@ class OutscaleGateway:
         self._load_gateway_structure()
         self._load_errors()
         self.log = Logger()
-        self.call = Call(logger=self.log, **kwargs)
+        self.call = Call(logger=self.log, version=self.endpoint_api_version, **kwargs)
 
     def update_credentials(self, **kwargs):
         """
@@ -104,6 +104,7 @@ class OutscaleGateway:
         except Exception as err:
             print("Problem reading {}:{}".format(input_file, str(err)))
         self.api_version = content["info"]["version"]
+        self.endpoint_api_version = content["servers"][0]["url"].split("/")[-1]
         for action, params in content["components"]["schemas"].items():
             if action.endswith("Request"):
                 action_name = action.split("Request")[0]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -10,14 +10,14 @@ class TestLog(unittest.TestCase):
         gw.log.config(type=LOG_MEMORY, what=LOG_KEEP_ONLY_LAST_REQ)
         gw.ReadVms()
         self.assertEqual(gw.log.str(),
-                         """uri: /api/latest/ReadVms
+                         """uri: /api/v1/ReadVms
 payload:
 {}"""
                          )
 
         gw.ReadVms(Filters={'TagKeys': ['test']})
         self.assertEqual(gw.log.str(),
-                         """uri: /api/latest/ReadVms
+                         """uri: /api/v1/ReadVms
 payload:
 {
   "Filters": {


### PR DESCRIPTION
Use api endpoint defined into the specification (instead of latest) to avoid breaking existing application if a major changes get released