### PR TITLE
⚰️ cleanup: remove legacy config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Example:
 
 Notes:
 
-* If `~/.osc/config.json` is not found, `~/.oapi_credentials` will be used as a fallback.
 * Environment variables have priority over credentials files.
 
 ### Basic Authentication

--- a/osc_sdk_python/credentials.py
+++ b/osc_sdk_python/credentials.py
@@ -2,7 +2,6 @@ import json
 import os
 import warnings
 
-ORIGINAL_PATH = os.path.join(os.path.expanduser("~"), ".oapi_credentials")
 STD_PATH = os.path.join(os.path.expanduser("~"), ".osc/config.json")
 DEFAULT_REGION = "eu-west-2"
 DEFAULT_PROFILE = "default"


### PR DESCRIPTION
## Description

Remove ~/.oapi_credentials from documentation, as it is not used anymore

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [x] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
