### PR TITLE
:bug: Fix #236: stop forwarding backoff_jitter to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The following options can be provided when initializing the `Gateway` to customi
 * `retry_backoff_jitter` (float, default `3.0`)
 * `retry_backoff_max` (float, default `30`)
 
-These correspond to their counterparts in [`urllib3.util.Retry`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry).
+These options follow the same behavior as their counterparts in [`urllib3.util.Retry`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry), but are implemented by the SDK retry logic.
 
 Example:
 

--- a/osc_sdk_python/retry.py
+++ b/osc_sdk_python/retry.py
@@ -24,16 +24,16 @@ class Retry:
         # Extract all retry parameters
         self.attempt: int = int(self.request_kwargs.pop("attempt", 0))
         self.max_retries: int = int(
-            self.request_kwargs.get("max_retries", MAX_RETRIES)
+            self.request_kwargs.pop("max_retries", MAX_RETRIES)
         )
         self.backoff_factor: float = float(
-            self.request_kwargs.get("backoff_factor", RETRY_BACKOFF_FACTOR)
+            self.request_kwargs.pop("backoff_factor", RETRY_BACKOFF_FACTOR)
         )
         self.backoff_jitter: float = float(
-            self.request_kwargs.get("backoff_jitter", RETRY_BACKOFF_JITTER)
+            self.request_kwargs.pop("backoff_jitter", RETRY_BACKOFF_JITTER)
         )
         self.backoff_max: float = float(
-            self.request_kwargs.get("backoff_max", RETRY_BACKOFF_MAX)
+            self.request_kwargs.pop("backoff_max", RETRY_BACKOFF_MAX)
         )
 
     def execute_once(self) -> requests.Response:
@@ -47,7 +47,15 @@ class Retry:
         Return a copy of the retry with an incremented attempt count
         """
         new_kwargs = self.request_kwargs.copy()
-        new_kwargs["attempt"] = self.attempt + 1
+        new_kwargs.update(
+            {
+                "attempt": self.attempt + 1,
+                "max_retries": self.max_retries,
+                "backoff_factor": self.backoff_factor,
+                "backoff_jitter": self.backoff_jitter,
+                "backoff_max": self.backoff_max,
+            }
+        )
         return Retry(self.session, self.method, self.url, **new_kwargs)
 
     def should_retry(self, e: requests.exceptions.RequestException) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "requests>=2.20.0",
     "ruamel.yaml==0.19.1",
-    "urllib3>=2.6.3",
+    "urllib3>=1.26.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ dev = [
 requires-dist = [
     { name = "requests", specifier = ">=2.20.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=1.26.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Description

- Fixes compatibility with urllib3 1.26.x, which is required by some boto3/botocore versions.
- Retry options (`max_retries`, `backoff_factor`, `backoff_jitter`, and `backoff_max`) are now handled entirely by the SDK retry logic and are no longer forwarded to `requests`, preventing unexpected keyword argument errors.
- Custom retry settings are preserved across retry attempts by restoring them when creating subsequent `Retry` instances.
- The minimum `urllib3` requirement is relaxed from `>=2.6.3` to `>=1.26.0`.


Fixes: #236 

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):

```bash
# Example
my-cli-tool build --verbose
my-cli-tool test
````

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [ ] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [ ] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
